### PR TITLE
Address #11. Monitoring the size of the install directory and quit wh…

### DIFF
--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -23,15 +23,40 @@ script:
         description: Creating Wine prefix
         name: create_prefix
         prefix: $GAMEDIR
-    - task:
-        description: Leave the installation path as default and advance through the dialogue. After clicking install the installer will appear to freeze. This is expected, and the installer still works in the background. After waiting about one minute you can close the Jagex Launcher with the following command "ps aux | grep 'cache/lutris/installer/jagex-launcher/jagexlauncher/' | grep -v grep | awk '{print $2}' | xargs kill"
-        executable: $GAMEDIR/drive_c/windows/explorer.exe
-        args: jagexlauncher
-        include_processes: explorer.exe
-        name: wineexec
-        prefix: $GAMEDIR
-        overrides:
-          jscript.dll: native
+    - execute:
+        command: |
+          set -x
+          # Run the installer using the wine version set in the installer script and override jscript .dll in the native version. Start the jagex installer in the background so we can monitor the install directory size.
+          # We need to do this because the gui window freezes normally and does not allow users to close it.
+          WINEPREFIX="$GAMEDIR" WINEDLLOVERRIDES="jscript.dll=n" "$WINEBIN" "$jagexlauncher" &
+          # Grab the pid of the installer process
+          installer_process="$!"
+
+          above_200=0
+
+          echo "Beginning installation..."
+
+          while true 
+          do
+              echo "Checking directory size..."
+              # Grab directory size for jagex launcher install directory. This is how we know when to kill the installer window.
+              dir_size=$(((du -sh "${GAMEDIR}/drive_c/Program Files (x86)/Jagex Launcher" 2> /dev/null) || echo '0G') | awk '{ print $1 }')
+              # Remove the last character from the dir_size so the units don't show
+              dir_size=$(echo "$dir_size" | sed 's/.$//')
+
+              # If the directory size is above 200M, then add one to the above_200 variable
+              if (( $dir_size > 200 )); then
+                  above_200=$((above_200+1))
+              fi
+
+              # If the directory has been above 200M for 20 seconds, then the installer is likely done and we can kill the window.
+              if (( $above_200 > 1 )); then
+                  kill "$installer_process"
+                  break # Exit the while loop
+              fi
+              sleep 10
+          done;
+        description: Leave the installation path default. After you click install, the client will appear to freeze. This is normal. It should quit within 2 minutes and continue. 
     - task:
         name: winekill
         prefix: $GAMEDIR


### PR DESCRIPTION
…en it is above 200MB for 20 seconds.


The makes it so users no longer need to run `xkill` or `ps aux | grep 'cache/lutris/installer/jagex-launcher/jagexlauncher/' | grep -v grep | awk '{print $2}' | xargs kill`