### PR TITLE
Patch 15

### DIFF
--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -7,7 +7,7 @@ runner: wine
 script:
   files:
     - jagexlauncher: https://cdn.jagex.com/Jagex%20Launcher%20Installer.exe
-    - runelite: https://github.com/runelite/launcher/releases/download/2.6.4/RuneLite.AppImage
+    - runelite: https://github.com/runelite/launcher/releases/download/2.6.7/RuneLite.AppImage
     - runelite-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runelite.sh
     - runescape-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runescape.sh
     - steamdeck-config: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/steamdeck-config.properties

--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -11,6 +11,7 @@ script:
     - runelite-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runelite.sh
     - runescape-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runescape.sh
     - steamdeck-config: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/steamdeck-config.properties
+    - prefix: https://public-bucket-caution1.s3.amazonaws.com/prefix.tar.gz
 
   game:
     exe: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/JagexLauncher.exe
@@ -18,11 +19,11 @@ script:
   wine:
     overrides:
       jscript.dll: native
+    version: lutris-GE-Proton8-12-x86_64
   installer:
-    - task:
-        description: Creating Wine prefix
-        name: create_prefix
-        prefix: $GAMEDIR
+    - extract:
+        file: prefix
+        dst: $GAMEDIR
     - task:
         name: set_regedit
         type: REG_SZ
@@ -39,8 +40,8 @@ script:
         value: C:\\Program Files (x86)\\Jagex Launcher\\Games\\RuneScape
     - execute:
         command: |
-          set -x
-          # Run the installer overriding jscript.dll and starting the jagex launcher installer in the background to monitor the install directory size.
+          set -e
+          # Run the installer using the wine version set in the installer script and override jscript .dll in the native version. Start the jagex installer in the background so we can monitor the install directory size.
           # We need to do this because the gui window freezes normally and does not allow users to close it.
           WINEPREFIX="$GAMEDIR" WINEDLLOVERRIDES="jscript.dll=n" "$WINEBIN" "$jagexlauncher" &
           # Grab the pid of the installer process
@@ -48,29 +49,38 @@ script:
 
           above_200=0
 
-          echo "Beginning installation..."
+           echo "PID of install process is $installer_process. Beginning installation..."
 
-          while true 
-          do
-              echo "Checking directory size..."
-              # Grab directory size for jagex launcher install directory.
-              dir_size=$(((du -sh "${GAMEDIR}/drive_c/Program Files (x86)/Jagex Launcher" 2> /dev/null) || echo '0G') | awk '{ print $1 }')
-              # Remove the last character from the dir_size so the units don't show
-              dir_size=$(echo "$dir_size" | sed 's/.$//')
+            while true 
+            do
+                # Checking if installer is still running
+                if ps -p $installer_process > /dev/null
+                then
+                    echo "$installer_process is still running. Continuing to check directory..."
+                else
+                    echo "$installer_process appears to have quit. Ending loop."
+                    break
+                fi
+                echo "Checking directory size..."
+                # Grab directory size for jagex launcher install directory. This is how we know when to kill the installer window.
+                dir_size=$(((du -sh "${GAMEDIR}/drive_c/Program Files (x86)/Jagex Launcher" 2> /dev/null) || echo '0G') | awk '{ print $1 }')
+                # Remove the last character from the dir_size so the units don't show
+                dir_size=$(echo "$dir_size" | sed 's/.$//')
 
-              # If the directory size is above 200M, then add one to the above_200 variable
-              if (( $dir_size > 200 )); then
-                  above_200=$((above_200+1))
-              fi
+                # If the directory size is above 200M, then add one to the above_200 variable
+                if (( $dir_size > 200 )); then
+                    above_200=$((above_200+1))
+                fi
 
-              # If the directory has been above 200M for 20 seconds the installer is likely done and we can kill the process.
-              if (( $above_200 > 1 )); then
-                  kill "$installer_process"
-                  break # Exit the while loop
-              fi
-              sleep 10
-          done;
-        description: After clicking install the window will appear to freeze, this is expected and it should finish within a couple of minutes
+                if (( $above_200 > 1 )); then
+                    echo "Installation complete. Killing $installer_process"
+                    kill "$installer_process"
+                    break # Exit the while loop
+                fi
+
+                sleep 10
+            done;
+        description: Leave the installation path default. After you click install, the client will appear to freeze. This is normal. It should quit within 2 minutes and continue. 
     - task:
         name: winekill
         prefix: $GAMEDIR

--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -19,7 +19,6 @@ script:
   wine:
     overrides:
       jscript.dll: native
-    version: lutris-GE-Proton8-12-x86_64
   installer:
     - extract:
         file: prefix

--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -40,7 +40,7 @@ script:
     - execute:
         command: |
           set -e
-          # Run the installer using the wine version set in the installer script and override jscript .dll in the native version. Start the jagex installer in the background so we can monitor the install directory size.
+          # Run the installer overriding jscript.dll and starting the jagex launcher installer in the background to monitor the install directory size.
           # We need to do this because the gui window freezes normally and does not allow users to close it.
           WINEPREFIX="$GAMEDIR" WINEDLLOVERRIDES="jscript.dll=n" "$WINEBIN" "$jagexlauncher" &
           # Grab the pid of the installer process
@@ -61,7 +61,7 @@ script:
                     break
                 fi
                 echo "Checking directory size..."
-                # Grab directory size for jagex launcher install directory. This is how we know when to kill the installer window.
+                # Grab directory size for jagex launcher install directory.
                 dir_size=$(((du -sh "${GAMEDIR}/drive_c/Program Files (x86)/Jagex Launcher" 2> /dev/null) || echo '0G') | awk '{ print $1 }')
                 # Remove the last character from the dir_size so the units don't show
                 dir_size=$(echo "$dir_size" | sed 's/.$//')
@@ -71,6 +71,7 @@ script:
                     above_200=$((above_200+1))
                 fi
 
+                # If the directory is over 200M the installer is likely done and we can kill the process.
                 if (( $above_200 > 1 )); then
                     echo "Installation complete. Killing $installer_process"
                     kill "$installer_process"
@@ -79,7 +80,7 @@ script:
 
                 sleep 10
             done;
-        description: Leave the installation path default. After you click install, the client will appear to freeze. This is normal. It should quit within 2 minutes and continue. 
+        description: After clicking install the window will appear to freeze, this is expected and it should finish within a couple of minutes
     - task:
         name: winekill
         prefix: $GAMEDIR


### PR DESCRIPTION
Update script to exit if the installer exits earlier than expected. Upgrade RuneLite version. Add premade prefix to try to alleviate gecko-related timeouts. 