### PR TITLE
Update jagexlauncher.yml

### DIFF
--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -43,10 +43,13 @@ script:
         command: |
           set -e
 
-          # Install gecko
-          mkdir -p "$XDG_CACHE_HOME/wine"
-          mv "$gecko" "$XDG_CACHE_HOME/wine/"
-          mv "$gecko_32" "$XDG_CACHE_HOME/wine/"
+          if [ -n "$XDG_CACHE_HOME" ]; then
+              mkdir -p "$XDG_CACHE_HOME/wine"
+              mv "$gecko" "$XDG_CACHE_HOME/wine/"
+              mv "$gecko_32" "$XDG_CACHE_HOME/wine/"
+          else
+              echo "XDG_CACHE_HOME is not set. Letting wine handle gecko installation."
+          fi
 
           # Run the installer overriding jscript.dll and starting the jagex launcher installer in the background to monitor the install directory size.
           # We need to do this because the gui window freezes normally and does not allow users to close it.


### PR DESCRIPTION
Address #64 and #66. XDG_CACHE_HOME is not consistently set in all operating systems, so added a check to only pre-install gecko if that variable exists. 