### PR TITLE
Runescape running on GPU instead of Intel 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains instruction on how to install the Jagex Launcher in Lin
 * [Flatpak](https://www.flatpak.org/setup)<br>
 * [Lutris](https://flathub.org/apps/net.lutris.Lutris)<br>
 * [Installation script](https://github.com/TormStorm/jagex-launcher-linux/blob/main/resources/jagexlauncher.yml)<br>
+* [Nvidia Offloader]
 
 ### Installation
 
@@ -21,7 +22,13 @@ This repository contains instruction on how to install the Jagex Launcher in Lin
 3. Follow the on screen instructions leaving the installation directory as default<br>
 
 - To play RuneScape simply install it from FlatHub<br>
+- Runescape will run on the intel graphics card
 
+### To use the nvidia GPU 
+ - Enable Nvidia offloader
+       -- create a new 10-nvidia.conf in /etc/X11/xorg.conf.d/
+       -- Reboot
+       -- Verify that the configration worked using __NV_PRIME_RENDER_OFFLOAD=1 __GLX_VENDOR_LIBRARY_NAME=nvidia glxinfo | grep "OpenGL vendor" : you should the output "NVIDIA Corporation" 
 ### Steam Deck
 
 > **Note**<br>

--- a/resources/runescape.sh
+++ b/resources/runescape.sh
@@ -3,6 +3,8 @@ set -e
 flatpak run --env=PULSE_LATENCY_MSEC=200 \
     --env='vblank_mode=0' \
     --env='MESA_GL_VERSION_OVERRIDE=4.5FC' \
+    --env='__NV_PRIME_RENDER_OFFLOAD=1' \
+    --env='__GLX_VENDOR_LIBRARY_NAME=nvidia' \
     com.jagex.RuneScape || \
 flatpak-spawn --host flatpak run \
     --env=PULSE_LATENCY_MSEC=200 \
@@ -13,4 +15,6 @@ flatpak-spawn --host flatpak run \
     --env=JX_DISPLAY_NAME="$JX_DISPLAY_NAME" \
     --env=JX_REFRESH_TOKEN="$JX_REFRESH_TOKEN" \
     --env=JX_SESSION_ID="$JX_SESSION_ID" \
+    --env='__NV_PRIME_RENDER_OFFLOAD=1' \
+    --env='__GLX_VENDOR_LIBRARY_NAME=nvidia' \
     com.jagex.RuneScape


### PR DESCRIPTION
After the latest patch of disabling external login using Jagex launcher was the only option. But it was running on intel gpu (mesa) horrible fps. Cant get any new prs :P . This new configration will enable runescape to run using nvidia GPU. 
Tried enabling it from lutris but runescape.sh overrides those setttings.