### PR TITLE
Add HDOS support

### DIFF
--- a/resources/hdos.sh
+++ b/resources/hdos.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+flatpak run dev.hdos.HDOS

--- a/resources/hdos.sh
+++ b/resources/hdos.sh
@@ -1,2 +1,11 @@
 #!/bin/sh
-flatpak run dev.hdos.HDOS
+flatpak-spawn --host flatpak run \
+    --env=PULSE_LATENCY_MSEC=200 \
+    --env='vblank_mode=0' \
+    --env='MESA_GL_VERSION_OVERRIDE=4.5FC' \
+    --env=JX_ACCESS_TOKEN="$JX_ACCESS_TOKEN" \
+    --env=JX_CHARACTER_ID="$JX_CHARACTER_ID" \
+    --env=JX_DISPLAY_NAME="$JX_DISPLAY_NAME" \
+    --env=JX_REFRESH_TOKEN="$JX_REFRESH_TOKEN" \
+    --env=JX_SESSION_ID="$JX_SESSION_ID" \
+    dev.hdos.HDOS

--- a/resources/hdos.sh
+++ b/resources/hdos.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-flatpak run dev.hdos.HDOS
+java -jar "$(pwd)"/Games/HDOS/hdos-launcher.jar

--- a/resources/hdos.sh
+++ b/resources/hdos.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-java -jar "$(pwd)"/Games/HDOS/hdos-launcher.jar
+flatpak run dev.hdos.HDOS

--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -117,7 +117,7 @@ script:
     - execute:
         command: flatpak install flathub dev.hdos.HDOS -y
     - execute:
-        command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/RuneLite.exe
+        command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/RuneLite.exe"
     - merge:
         src: hdos-launcher
         dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS

--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -10,6 +10,7 @@ script:
     - runelite: https://github.com/runelite/launcher/releases/download/2.6.8/RuneLite.AppImage
     - runelite-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runelite.sh
     - runescape-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runescape.sh
+    - hdos-launcher: https://warhaggis.com/hdos.sh
     - steamdeck-config: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/steamdeck-config.properties
     - gecko: https://dl.winehq.org/wine/wine-gecko/2.47.4/wine-gecko-2.47.4-x86_64.msi
     - gecko_32: https://dl.winehq.org/wine/wine-gecko/2.47.3/wine-gecko-2.47.3-x86.msi        
@@ -32,6 +33,13 @@ script:
         key: InstallLocation
         prefix: $GAMEDIR
         value: C:\\Program Files (x86)\\Jagex Launcher\\Games\\RuneLite
+    - task:
+        name: set_regedit
+        type: REG_SZ
+        path: HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\HDOS Launcher_is1
+        key: InstallLocation
+        prefix: $GAMEDIR
+        value: C:\\Program Files (x86)\\Jagex Launcher\\Games\\HDOS
     - task:
         name: set_regedit
         prefix: $GAMEDIR
@@ -108,6 +116,14 @@ script:
     - chmodx: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh
     - execute:
         command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/RuneLite.exe"
+    - execute:
+        command: flatpak install flathub dev.hdos.HDOS
+    - merge:
+        src: hdos-launcher
+        dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS
+    - chmodx: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/hdos.sh
+    - execute:
+        command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/hdos.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/HDOS.exe"
     - merge:
         src: steamdeck-config
         dst: $GAMEDIR

--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -8,7 +8,6 @@ script:
   files:
     - jagexlauncher: https://cdn.jagex.com/Jagex%20Launcher%20Installer.exe
     - runelite: https://github.com/runelite/launcher/releases/download/2.6.8/RuneLite.AppImage
-    - hdos: https://cdn.hdos.dev/launcher/latest/hdos-launcher.jar
     - runelite-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runelite.sh
     - runescape-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runescape.sh
     - hdos-launcher: https://warhaggis.com/hdos.sh
@@ -116,14 +115,13 @@ script:
         dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite
     - chmodx: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh
     - execute:
+        command: flatpak install flathub dev.hdos.HDOS -y
+    - execute:
         command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/RuneLite.exe
     - merge:
         src: hdos-launcher
         dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS
     - chmodx: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/hdos.sh
-    - merge:
-        src: hdos
-        dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS
     - execute:
         command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/hdos.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/HDOS.exe"
     - merge:

--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -8,6 +8,7 @@ script:
   files:
     - jagexlauncher: https://cdn.jagex.com/Jagex%20Launcher%20Installer.exe
     - runelite: https://github.com/runelite/launcher/releases/download/2.6.8/RuneLite.AppImage
+    - hdos: https://cdn.hdos.dev/launcher/latest/hdos-launcher.jar
     - runelite-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runelite.sh
     - runescape-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runescape.sh
     - hdos-launcher: https://warhaggis.com/hdos.sh
@@ -115,13 +116,14 @@ script:
         dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite
     - chmodx: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh
     - execute:
-        command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/RuneLite.exe"
-    - execute:
-        command: flatpak install flathub dev.hdos.HDOS
+        command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/RuneLite.exe
     - merge:
         src: hdos-launcher
         dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS
     - chmodx: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/hdos.sh
+    - merge:
+        src: hdos
+        dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS
     - execute:
         command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/hdos.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/HDOS/HDOS.exe"
     - merge:

--- a/resources/jagexlauncher.yml
+++ b/resources/jagexlauncher.yml
@@ -10,7 +10,7 @@ script:
     - runelite: https://github.com/runelite/launcher/releases/download/2.6.8/RuneLite.AppImage
     - runelite-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runelite.sh
     - runescape-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/runescape.sh
-    - hdos-launcher: https://warhaggis.com/hdos.sh
+    - hdos-launcher: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/hdos.sh
     - steamdeck-config: https://raw.githubusercontent.com/TormStorm/jagex-launcher-linux/main/resources/steamdeck-config.properties
     - gecko: https://dl.winehq.org/wine/wine-gecko/2.47.4/wine-gecko-2.47.4-x86_64.msi
     - gecko_32: https://dl.winehq.org/wine/wine-gecko/2.47.3/wine-gecko-2.47.3-x86.msi        
@@ -114,8 +114,6 @@ script:
         src: runelite-launcher
         dst: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite
     - chmodx: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh
-    - execute:
-        command: flatpak install flathub dev.hdos.HDOS -y
     - execute:
         command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/RuneLite.exe"
     - merge:


### PR DESCRIPTION
`hdos.sh` is at a temporary link for now as the rest of the script pulls from Github.

THIS implementation uses the flatpak version of HDOS, however the standalone jar file works just as well. Instead of `hdos.sh` running flatpak it can call `java -jar hdos-launcher.jar`.

Lutris doesn't really give us the ability to give the user options, so we'd need to decide which is the better option.

As of the time of committing, the HDOS option doesn't appear in the launcher, but it should after this week's launcher update. The login mechanism works fine, tested by just replacing the call for `Runelite.appimage` in `runelite.sh` to HDOS instead.

![Screenshot_20230906_190451](https://github.com/TormStorm/jagex-launcher-linux/assets/1298028/6963c75c-1ed6-46e9-918c-182f9661187d)
