### PR TITLE
Python 3 is required in order to install Jagex Launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ I am not responsible for the maintenance and safety of content produced and host
 * [Lutris v0.5.14](https://flathub.org/apps/net.lutris.Lutris)<br>
 * [Latest project release](https://github.com/TormStorm/jagex-launcher-linux/releases/)<br>
 
+* Python 3 and Python 3 venv
+
+For Ubuntu users:
+```
+$ sudo apt install -y python3 python3-venv
+```
+---
+
 1. Get the requirements from the links above and extract the source code<br>
 2. Open Lutris, click the `+` in the top left corner and select `Install from a local install script`<br>
 3. Select `jagex-launcher.yml`  and follow the on screen instructions leaving the installation directory as default<br>

--- a/resources/jagex-launcher.yml
+++ b/resources/jagex-launcher.yml
@@ -66,10 +66,10 @@ script:
             fi
             mkdir -p "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher"
             cd "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher"
-            python -m venv env
+            python3 -m venv env
             source env/bin/activate
-            python -m pip install -r "$requirements"
-            python "$installer"
+            python3 -m pip install -r "$requirements"
+            python3 "$installer"
         description: Installing the jagex-launcher files
     - task:
         name: winekill


### PR DESCRIPTION
Tested the version v1.0.0 of Jagex Launcher Linux.

Installation is fast and I was able to install RuneScape Client using the own Jagex Launcher (without the need of install it via flatpak) and it's working smoothly.

The small fix is to install python3 and python3-env since they are required to run the installer of this repository.