### PR TITLE
README: There are multiple Flatpaks available

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ This repository contains instruction on how to install the Jagex Launcher in Lin
 
 ## Official Jagex Launcher
 
-Download the latest [Jagex Launcher Flatpak](https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher/releases) and install it with the following command:<br>
-```
-curl -s https://raw.githubusercontent.com/nmlynch94/com.jagexlauncher.JagexLauncher/main/install-jagex-launcher.sh | TERM=dumb bash
-```
-For more information visit nmlynch94's [GitHub page](https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher)
+There are multiple Flatpak packages available for the Jagex Launcher.
+
+- <https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher>
+- <https://github.com/USA-RedDragon/jagex-launcher-flatpak>
+
+See the relevant repositories for installation instructions.
 
 ## Third-party launcher
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,23 @@ This repository contains instruction on how to install the Jagex Launcher in Lin
 
 ## Official Jagex Launcher
 
-There are multiple Flatpak packages available for the Jagex Launcher.
+There are multiple Flatpaks available, we recommend using this one from USA-RedDragon:
+```
+curl -fSsL https://raw.githubusercontent.com/USA-RedDragon/jagex-launcher-flatpak/main/install.sh | bash
+```
+For more information visit USA-RedDragon's [GitHub page](https://github.com/USA-RedDragon/jagex-launcher-flatpak)<br>
+<br>
 
-- <https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher>
-- <https://github.com/USA-RedDragon/jagex-launcher-flatpak>
 
-See the relevant repositories for installation instructions.
+Alternatively you can use nmlynch94's Flatpak:
+```
+wget https://raw.githubusercontent.com/nmlynch94/com.jagexlauncher.JagexLauncher/main/install-jagex-launcher.sh && bash install-jagex-launcher.sh && rm install-jagex-launcher.sh
+```
+For more information visit nmlynch94's [GitHub page](https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher)
 
 ## Third-party launcher
 
-Alternatively you can install a native third-party launcher from [Flathub](https://flathub.org/setup) with the following command:<br>
+If you want to use a native third-party launcher you can install Bolt:<br>
 ```
 flatpak install flathub com.adamcake.Bolt
 ```


### PR DESCRIPTION
It looks like nmlynch94 and I started working on Flatpaks around the same time. We take two completely different approaches for these Flatpaks and more options are always better for the FOSS community in the event one should become unmaintained.

Some of the ways my Flatpak is different:

#### Wine

The `nmlynch94` launcher [uses](https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher/blob/6e1b5bf4c78b707bcb15d6f85d8b48e0337b7525/com.jagex.Launcher.yml#L21-L23) the [unoffical Flatpak Wine](https://github.com/flathub/org.winehq.Wine) package. This package is not maintained by the Wine project and is several versions behind. This has several effects:

- This unofficial Wine package is missing many of the improvements that have been made to Wine recently.
- Because the unofficial Wine Flatpak is meant to be a one-size-fits-all installation of Wine, the size of the Flatpak is much larger than it needs to be, because it includes many dependencies that are not needed by the Jagex Launcher and it's games.
- The permissions required for the unofficial Wine are larger because it requests access to the host filesystem along with accessing devices. This is not needed by the Jagex Launcher and it's games, so these permissions expand the attack surface of the Flatpak without providing any benefit.

`nmlynch94`'s Flatpak also [contains a prebuilt Proton GE](https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher/blob/35b90122cffb994bf506d0d36939bdb14c308973/com.jagex.Launcher.yml#L55-L65) which makes the Wine base even more unnecessary and illogical.

#### DXVK

The Jagex Launcher, Runescape's NXT client, the official OSRS client, and RuneLite all use OpenGL. (The exception is running NXT with compatibility mode) The `nmlynch94` launcher [adds DXVK](https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher/blob/35b90122cffb994bf506d0d36939bdb14c308973/com.jagex.Launcher.yml#L99-L108), which just adds overhead and goes unused.

#### Custom Clients

The `nmlynch94` launcher contains support for other clients such as HDOS. If these clients are important to you, you should use the `nmlynch94` launcher. However, if you only care about the official Jagex client and RuneLite, my launcher is a better option.

#### Coherent Commit Messages

The `nmlynch94` launcher's [commit history](https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher/commits/35b90122cffb994bf506d0d36939bdb14c308973) is littered with commit messages like "Update <filename>" and "test", so understanding the changes that were made to the repo is difficult.

#### Continuous Integration

My Flatpak also uses [GitHub Actions](https://github.com/features/actions) to test changes and ensure the Flatpak builds successfully. This means that the Flatpak will always be tested before being released and allows the next benefit: automatic dependency updates.

#### Automatic Dependency Updates

My Flatpak repository uses [Renovate](https://www.mend.io/renovate/) to create automated pull requests to update dependencies. This means that the dependencies will be kept up to date without any manual intervention. This ensures that users will always have the latest versions of Wine and Runelite. `nmlynch94` does not use CI or Renovate, so the dependency update process is manual.

#### Copyrighted Content

My Flatpak repository contains zero content that is the intellectual property of Jagex which allows it to be open sourced under a very permissive license. The `nmlynch94` launcher [contains the Jagex launcher logo](https://github.com/nmlynch94/com.jagexlauncher.JagexLauncher/blob/6e1b5bf4c78b707bcb15d6f85d8b48e0337b7525/icons/512/512.png) that belongs to Jagex.

The lack of a license on the `nmlynch94` repository means that it is not legal to distribute or modify `nmlynch94`'s launcher package and that it is proprietary.
