### PR TITLE
Update README.md to simplify Steam Deck instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ For more information visit adamcake's [Flathub page](https://github.com/flathub/
 
 ## Steam Deck
 
-Install BoilR from the discover store<br>
-Select Import Games and make sure the Jagex Launcher is checked<br>
-Click the import games button on the bottom left and restart steam<br>
-Rename the Steam entry to RuneScape if playing RuneScape or OSRS if playing Old School RuneScape<br>
-Press the steam button, controller settings, browse community layouts and select a controller layout<br>
+Open the application menu and right click on "Jagex Launcher" in the "Games" category  
+Select "Add to Steam"  
+Rename the Steam entry to RuneScape if playing RuneScape or OSRS if playing Old School RuneScape  
+Switch to Gaming Mode by logging out  
+Your new shortcut should now be in your library under "Non-Steam"  
+After launching, press the steam button and you can browse community layouts under "Controller Settings" to configure your controls  
 
 ### Additional information
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ flatpak install flathub com.adamcake.Bolt
 For more information visit adamcake's [Flathub page](https://github.com/flathub/com.adamcake.Bolt)
 
 ## Steam Deck
-Switch to the desktop and open the application menu. Right click the Jagex Launcher under games and select add to Steam<br>
+Switch to the desktop and open the application menu. Right click the Jagex Launcher and select add to Steam<br>
 Switch back to Gaming Mode, your new shortcut should now be in your library under `Non-Steam`<br>
-Rename the Steam entry to RuneScape if playing RuneScape or OSRS if playing Old School RuneScape<br>
-You can configure your controls by going to the game's controller settings and browse community layouts
+Rename the Steam entry to `RuneScape` if playing RuneScape or `OSRS` if playing Old School RuneScape<br>
+You can configure your controls by going into the game's controller settings and browse community layouts
 
 ### Additional information
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,10 @@ flatpak install flathub com.adamcake.Bolt
 For more information visit adamcake's [Flathub page](https://github.com/flathub/com.adamcake.Bolt)
 
 ## Steam Deck
-
-Open the application menu and right click on "Jagex Launcher" in the "Games" category  
-Select "Add to Steam"  
-Rename the Steam entry to RuneScape if playing RuneScape or OSRS if playing Old School RuneScape  
-Switch to Gaming Mode by logging out  
-Your new shortcut should now be in your library under "Non-Steam"  
-After launching, press the steam button and you can browse community layouts under "Controller Settings" to configure your controls  
+Switch to the desktop and open the application menu. Right click the Jagex Launcher under games and select add to Steam<br>
+Switch back to Gaming Mode, your new shortcut should now be in your library under `Non-Steam`<br>
+Rename the Steam entry to RuneScape if playing RuneScape or OSRS if playing Old School RuneScape<br>
+You can configure your controls by going to the game's controller settings and browse community layouts
 
 ### Additional information
 


### PR DESCRIPTION
Steam Deck has added support for adding application shortcuts directly to steam, which is much more convenient and reliable than Boilr. Recommending users do that instead of Boilr.